### PR TITLE
Improve naming consistency

### DIFF
--- a/src/frontend/widgets/tool_box.py
+++ b/src/frontend/widgets/tool_box.py
@@ -26,7 +26,7 @@ class ToolBox(QToolBox):
                 inst = SlotInstance("Slot")
                 ToolboxView(GInputAction(TreeItem(["Input", 0, 0, 50, 50]), inst), self.system_actions_layout)
             else:
-                inst = instance.ActionInstance.create(action)
+                inst = instance.ActionCall.create(action)
                 ToolboxView(GAction(TreeItem([action.name, 0, 0, 50, 50]),
                                     inst), self.system_actions_layout)
 
@@ -54,7 +54,7 @@ class ToolBox(QToolBox):
             for item in module.definitions:
                 if not item.is_analysis and item.name != curr_workspace.scene.workflow.name:
                     ToolboxView(GAction(TreeItem([item.name, 0, 0, 50, 50]),
-                                        instance.ActionInstance.create(item)), module_category)
+                                        instance.ActionCall.create(item)), module_category)
                     self.action_database[module.name][item.name] = item
 
             self.import_modules[module.name] = module_category

--- a/src/visip/__init__.py
+++ b/src/visip/__init__.py
@@ -1,37 +1,53 @@
+"""
+This module provides public interface of the VISIP language.
+Public names are:
+
+Decorators: workflow, analysis, action, Class
+
+wrapped actions:
+    list, tuple, dict, ...
+
+All underscored names are private
+"""
+
 from .action.wrapped import *
-from .dev.action_workflow import Slot
+from .dev.action_workflow import _Slot as _Slot, _ResultCall as _Result
+from .action.constructor import Value as _Value
 from .code.decorators import workflow, analysis, action, Class
-from visip.action.converter import GetAttribute, GetItem #,GetKey
+from visip.action import converter as _converter
 from typing import List
 
 
 # TODO:
 # distinguish:
 # - wrapped actions, i.e. names used in workflow definitions
+#   e.g. list, dict, tuple, load_yaml
+#
 # - action instances, single instance for every base action class (used in following list and then in the frontend)
+#   list.action, dict.action, tuple.action, load_yaml.action
+#
 # - action classes (internal use only)
+#   A_list, A_dict, A_tuple
+#
 # Make unique naming scheme to clearly distinguish these objects.
 # Consider what should be in the visip namespace in particular which actions.
 #
 # Can we treat all actions in visip module directly instead of using following special list?
-base_system_actions = [Slot(),
-                       Value(None),   # can be deleted
+base_system_actions = [_Slot(),
+                       _Result(),
+                       _Value(None),   # can be deleted
                        list.action,
                        tuple.action,
                        dict.action,
-                       GetAttribute(None),
-                       GetItem(), #GetKey()
+                       _converter.GetAttribute(None),
+                       _converter.GetItem(), #GetKey()
                        ]
 
 """
 FUTURE:
-- possibly have different actions as instances of few dev classes carring just
-  different evaluate functions. Separate class only if code mechanism is substantialy different.
-  e.g. GenericAction, ListAction, OperatorAction, MetaAction (workflow, foreach, while, ..)
 - Resources:
     latency, speed, tags (supported features, HW, SW)  
-"""
-"""
+
 TODO:  
 - side_effect results - perform some actions for their sideefect, need a way to connect them to the result action instance
   that way result should have arbitrary number of parameters, but only the first is used (not good for a workflow with side effect but no true return value)
@@ -46,21 +62,7 @@ TODO:
     - must pass imports as a dictionalry to translate full module names to aliasses
     - implement full and iterative collection of used modules in definitions of the module
     #instance should  know its module path 
-4. test_gui_api, etc.
-
-1. Improved code generation:
-    - modify _code methods to return (instance_name, format, list of instance to substitute into the format)
-    - modify workspace code to dynamicaly expand format to obtain not extremaly long code representation:
-        try to expand:
-            - Value, dataclass instance, Tuple, List, GetAttribute ... should be the action property
-
-4. Simplest evaluation support.
-    - create Task DAG from the root analysis workflow.
-    - process the Task DAG (serialy directly in Python)
-
-
-
-
+4. test_gui_api, etc
 
 6. Typechecking
 

--- a/src/visip/action/constructor.py
+++ b/src/visip/action/constructor.py
@@ -58,7 +58,7 @@ class _ListBase(_ActionBase):
                                        default=self.parameters.no_default))
 
 
-class list_constr(_ListBase):
+class A_list(_ListBase):
     def __init__(self):
         super().__init__(action_name='list')
 
@@ -69,7 +69,7 @@ class list_constr(_ListBase):
         return list(inputs)
 
 
-class tuple_constr(_ListBase):
+class A_tuple(_ListBase):
     """
     This action is necessary only for better typechecking, using fixed number of items
     of given type.
@@ -84,7 +84,7 @@ class tuple_constr(_ListBase):
         return tuple(inputs)
 
 
-class dict_constr(_ActionBase):
+class A_dict(_ActionBase):
     def __init__(self):
         super().__init__(action_name='dict')
         self.parameters = Parameters()
@@ -97,13 +97,10 @@ class dict_constr(_ActionBase):
 
         return _ActionBase.format(self, representer, action_name, arg_names)
 
-
-
     def evaluate(self, inputs):
         return { key: val for key, val in inputs}
-
-        item_pairs = ( (key, val) for key, val in inputs)
-        return dict(item_pairs)
+        #item_pairs = ( (key, val) for key, val in inputs)
+        #return dict(item_pairs)
 
 """
 TODO: 
@@ -150,21 +147,12 @@ class ClassActionBase(_ActionBase):
         """
         return cls(cls.dataclass_from_params(name, params, module))
 
-
-
-    @staticmethod
-    def construct_from_class(data_class):
-
-        return
-
-
     @property
     def constructor(self):
         return self._data_class
 
     def _evaluate(self, *args) -> dtype.DataClassBase:
-        return self._data_class(*args)
-
+        return self.constructor(*args)
 
     def code_of_definition(self, representer, make_rel_name):
         """

--- a/src/visip/action/wrapped.py
+++ b/src/visip/action/wrapped.py
@@ -6,10 +6,8 @@ Problematic are actions generated from special constructs by the 'code' package:
 - actions that are already wrapped are just imported
 """
 from . import constructor
-from  .converter import *
 from ..code import wrap
-from .constructor import Value
 
-dict = wrap.public_action(constructor.dict_constr())
-list = wrap.public_action(constructor.list_constr())
-tuple = wrap.public_action(constructor.tuple_constr())
+dict = wrap.public_action(constructor.A_dict())
+list = wrap.public_action(constructor.A_list())
+tuple = wrap.public_action(constructor.A_tuple())

--- a/src/visip/code/decorators.py
+++ b/src/visip/code/decorators.py
@@ -36,7 +36,7 @@ def workflow(func):
         func_args.append(variables)
         param_names = param_names[1:]
 
-    slots = [wf.SlotInstance(name) for i, name in enumerate(param_names)]
+    slots = [wf.SlotCall(name) for i, name in enumerate(param_names)]
     dummies = [dummy.Dummy(slot) for slot in slots]
     func_args.extend(dummies)
     #print(func)

--- a/src/visip/code/decorators.py
+++ b/src/visip/code/decorators.py
@@ -36,7 +36,7 @@ def workflow(func):
         func_args.append(variables)
         param_names = param_names[1:]
 
-    slots = [wf.SlotCall(name) for i, name in enumerate(param_names)]
+    slots = [wf._SlotCall(name) for i, name in enumerate(param_names)]
     dummies = [dummy.Dummy(slot) for slot in slots]
     func_args.extend(dummies)
     #print(func)

--- a/src/visip/code/dummy.py
+++ b/src/visip/code/dummy.py
@@ -2,7 +2,7 @@ from typing import *
 from ..dev import base as base, action_instance as instance
 from ..action.converter import GetAttribute, GetItem
 from ..action.constructor import Value
-from ..dev.action_instance import ActionInstance
+from ..dev.action_instance import ActionCall
 
 
 def is_underscored(s:Any) -> bool:
@@ -24,8 +24,8 @@ class Dummy:
             return Dummy(action)
 
 
-    def __init__(self, action: instance.ActionInstance) -> None:
-        assert isinstance(action, instance.ActionInstance)
+    def __init__(self, action: instance.ActionCall) -> None:
+        assert isinstance(action, instance.ActionCall)
         self._action = action
         """Dummy pretend the data object of the action.output_type."""
 
@@ -36,12 +36,12 @@ class Dummy:
         # TODO: update the type to know that it is a dataclass containing 'key'
         # TODO: check that type is dataclass
         assert not is_underscored(key)
-        action = ActionInstance.create(GetAttribute(key), self._action)
+        action = ActionCall.create(GetAttribute(key), self._action)
         return Dummy.wrap(action)
 
     def __getitem__(self, idx: int):
-        idx_wrap = ActionInstance.create(Value(idx))
-        action = ActionInstance.create(GetItem(), self._action, idx_wrap)
+        idx_wrap = ActionCall.create(Value(idx))
+        action = ActionCall.create(GetItem(), self._action, idx_wrap)
         return Dummy.wrap(action)
 
     # Binary

--- a/src/visip/code/wrap.py
+++ b/src/visip/code/wrap.py
@@ -22,19 +22,19 @@ def into_action(value):
 
     if value is None:
         return None
-    elif isinstance(value, instance.ActionInstance):
+    elif isinstance(value, instance.ActionCall):
         return value
     elif dtype.is_base_type(type(value)):
-        return instance.ActionInstance.create(constructor.Value(value))
+        return instance.ActionCall.create(constructor.Value(value))
     elif type(value) is list:
         wrap_values = [into_action(val) for val in value]
-        return instance.ActionInstance.create(constructor.list_constr(), *wrap_values)
+        return instance.ActionCall.create(constructor.A_list(), *wrap_values)
     elif type(value) is tuple:
         wrap_values = [into_action(val) for val in value]
-        return instance.ActionInstance.create(constructor.tuple_constr(), *wrap_values)
+        return instance.ActionCall.create(constructor.A_tuple(), *wrap_values)
     elif type(value) is dict:
         wrap_values = [into_action((key, val)) for key, val in value.items()]
-        return instance.ActionInstance.create(constructor.dict_constr(), *wrap_values)
+        return instance.ActionCall.create(constructor.A_dict(), *wrap_values)
     elif isinstance(value, dummy.Dummy):
         return value._action
     else:
@@ -102,7 +102,7 @@ class ActionWrapper:
         kwargs = { key: into_action(val) for key, val in kwargs.items() }
         regular_inputs, private_args = separate_underscored_keys(kwargs)
         # print("Instance: ", self.action.name, args, regular_inputs)
-        action_instance = instance.ActionInstance.create(self.action, *args, **regular_inputs)
+        action_instance = instance.ActionCall.create(self.action, *args, **regular_inputs)
         # TODO: check that inputs are connected.
         # action_instance.set_metadata(private_args)
         return dummy.Dummy.wrap(action_instance)

--- a/src/visip/dev/action_instance.py
+++ b/src/visip/dev/action_instance.py
@@ -28,7 +28,7 @@ RemainingArgs = Dict[Union[int, str], '_ActionBase']
 
 
 
-class ActionInstance:
+class ActionCall:
     """
     The call of an action within a workflow. ActionInstance objects are vertices of the
     call graph (DAG).
@@ -69,7 +69,7 @@ class ActionInstance:
         :return:
         """
         assert isinstance(action, base._ActionBase), action.__class__
-        instance = ActionInstance(action)
+        instance = ActionCall(action)
         remaining_args, duplicate = instance.set_inputs(input_list=args, input_dict=kwargs)
         if remaining_args:
             raise base.ExcUnknownArgument(remaining_args)
@@ -97,14 +97,14 @@ class ActionInstance:
         if value is None:
             is_default, value = param.get_default()
             if is_default:
-                value = ActionInstance.create(Value(value))
+                value = ActionCall.create(Value(value))
 
         if value is None:
             return ActionArgument(param, None, False, ActionInputStatus.missing)
 
         # if not isinstance(value, ActionInstance):
         #     x = 1
-        assert isinstance(value, ActionInstance), type(value)
+        assert isinstance(value, ActionCall), type(value)
         if not dtype.is_subtype(value.output_type, param.type):
             return  ActionArgument(param, value, is_default, ActionInputStatus.error_type)
 

--- a/src/visip/dev/action_workflow.py
+++ b/src/visip/dev/action_workflow.py
@@ -17,7 +17,7 @@ Implementation of the Workflow composed action.
 class _Slot(base._ActionBase):
     pass
 
-class SlotCall(ActionCall):
+class _SlotCall(ActionCall):
     def __init__(self, slot_name):
         """
         Auxiliary action to connect to a named input slot of the workflow.
@@ -304,7 +304,7 @@ class _Workflow(base._ActionBase):
         self.update_parameters()
 
 
-    def insert_slot(self, i_slot:int, slot: SlotCall) -> None:
+    def insert_slot(self, i_slot:int, slot: _SlotCall) -> None:
         """
         Insert a new slot on i_th position shifting the slot on i-th position and remaining to the right.
         Change of the name

--- a/src/visip/dev/evaluation.py
+++ b/src/visip/dev/evaluation.py
@@ -271,9 +271,9 @@ class Evaluation:
         bind_name = 'all_bind_' + action.name
         workflow = _Workflow(bind_name)
 
-        bind_action = instance.ActionInstance.create(action)
+        bind_action = instance.ActionCall.create(action)
         for i, input in enumerate(inputs):
-            value_instance = instance.ActionInstance.create(Value(input))
+            value_instance = instance.ActionCall.create(Value(input))
             workflow.set_action_input(bind_action, i, value_instance)
             assert bind_action.arguments[i].status >= instance.ActionInputStatus.seems_ok
         workflow.set_action_input(workflow.result, 0, bind_action)

--- a/src/visip/dev/module.py
+++ b/src/visip/dev/module.py
@@ -8,7 +8,7 @@ from types import ModuleType
 from ..code import wrap
 from ..code.representer import Representer
 from . import base, action_workflow as wf, dtype as dtype
-from .action_instance import ActionInstance
+from .action_instance import ActionCall
 
 
 
@@ -74,27 +74,29 @@ class Module:
     """
 
 
-    @staticmethod
-    def catch_object(name, object):
-        """
-        Predicate to identify Analysis definitions in the modlue dict.
-        TODO: possibly catch without decorators
-        Currently:
-        - ignore underscored names
-        - ignore non-classes
-        - ignore classes not derived from _ActionBase
-        - print all non-underscore ignored names
-        """
+    # @staticmethod
+    # def catch_object(name, object):
+    #     """
+    #     Predicate to identify Analysis definitions in the modlue dict.
+    #     TODO: possibly catch without decorators
+    #     Currently:
+    #     - ignore underscored names
+    #     - ignore non-classes
+    #     - ignore classes not derived from _ActionBase
+    #     - print all non-underscore ignored names
+    #     """
+    #     pass
 
 
-    def __init__(self, module_file: str) -> None:
+
+    def __init__(self, module_path:str) -> None:
         """
         Constructor of the _Module wrapper.
-        :param module: a python module object
+        :param module_obj: a python module object
         """
-        self.module_file = module_file
+        self.module_file = module_path
         # File with the module source code.
-        self.module = self.load_module(module_file)
+        self.module = self.load_module(module_path)
         # Ref to wrapped python module object.
 
         self.definitions = []
@@ -116,15 +118,13 @@ class Module:
 
         self.extract_definitions()
 
-    # TODO: reintroduce _load_from_source for unit tests
-
-    def load_module(self, file_path: str) -> ModuleType:
+    @classmethod
+    def load_module(cls, file_path: str) -> ModuleType:
         """
         Import the python module from the file.
         Temporary add its directory to the sys.path in order to find modules in the same directory.
-
         TODO: Create an empty module if the file doesn't exist.
-        :param file:
+        :param file_path: Module path to load.
         :return:
         """
         module_dir = os.path.dirname(file_path)
@@ -137,7 +137,6 @@ class Module:
             new_module = imp.new_module(module_name)
             my_exec(source, new_module.__dict__, locals=None, description=module_name)
         return new_module
-
 
     def extract_definitions(self):
         """
@@ -167,7 +166,7 @@ class Module:
         if analysis:
             # make instance of the main workflow
             analysis = analysis[0]
-            self.analysis = ActionInstance.create(analysis)
+            self.analysis = ActionCall.create(analysis)
         else:
             self.analysis = None
 
@@ -260,8 +259,7 @@ class Module:
         analysis = [d for d in self.definitions if d.is_analysis]
         return analysis
 
-
-    def get_workflow(self, name: str) -> wf._Workflow:
+    def get_action(self, name: str) -> wf._Workflow:
         """
         Get the workflow by the name.
         :param name:

--- a/testing/dev/test_evaluation.py
+++ b/testing/dev/test_evaluation.py
@@ -12,9 +12,9 @@ def test_evaluation(src_file):
 
 
     mod = module.Module(source_in_path)
-    wf_test_class = mod.get_workflow(name='test_class')
-    assert sorted(list(wf_test_class._actions.keys())) == ['Point_1', '__result__', 'a', 'a_x', 'b', 'b_y']
-    Point = mod.get_workflow(name='Point')
+    wf_test_class = mod.get_action(name='test_class')
+    assert sorted(list(wf_test_class._action_calls.keys())) == ['Point_1', '__result__', 'a', 'a_x', 'b', 'b_y']
+    Point = mod.get_action(name='Point')
     pa = Point.constructor(x=0, y=1)
     pb = Point.constructor(x=2, y=3)
 
@@ -23,7 +23,7 @@ def test_evaluation(src_file):
     # binded action and few Value action instances.
     # Then make_analysis (which binds all parameters) can be replaced this more general feature.
     analysis = evaluation.Evaluation.make_analysis(wf_test_class, [pa, pb])
-    assert sorted(list(analysis._actions.keys())) == ['Value_1', 'Value_2', '__result__', 'test_class_1']
+    assert sorted(list(analysis._action_calls.keys())) == ['Value_1', 'Value_2', '__result__', 'test_class_1']
     eval = evaluation.Evaluation(analysis)
     result = eval.execute()
 

--- a/testing/dev/test_workflow.py
+++ b/testing/dev/test_workflow.py
@@ -7,14 +7,14 @@ def test_workflow_modification():
 
     ## Slot modifications
     # insert_slot
-    w.insert_slot(0, wf.SlotCall("a_slot"))
-    w.insert_slot(1, wf.SlotCall("b_slot"))
+    w.insert_slot(0, wf._SlotCall("a_slot"))
+    w.insert_slot(1, wf._SlotCall("b_slot"))
     assert w.parameters.size() == 2
     assert w.parameters.get_index(0).name == 'a_slot'
     assert w.parameters.get_index(1).name == 'b_slot'
 
     # move_slot
-    w.insert_slot(2, wf.SlotCall("c_slot"))
+    w.insert_slot(2, wf._SlotCall("c_slot"))
     # A B C
     w.move_slot(1, 2)
     # A C B

--- a/testing/dev/test_workflow.py
+++ b/testing/dev/test_workflow.py
@@ -7,14 +7,14 @@ def test_workflow_modification():
 
     ## Slot modifications
     # insert_slot
-    w.insert_slot(0, wf.SlotInstance("a_slot"))
-    w.insert_slot(1, wf.SlotInstance("b_slot"))
+    w.insert_slot(0, wf.SlotCall("a_slot"))
+    w.insert_slot(1, wf.SlotCall("b_slot"))
     assert w.parameters.size() == 2
     assert w.parameters.get_index(0).name == 'a_slot'
     assert w.parameters.get_index(1).name == 'b_slot'
 
     # move_slot
-    w.insert_slot(2, wf.SlotInstance("c_slot"))
+    w.insert_slot(2, wf.SlotCall("c_slot"))
     # A B C
     w.move_slot(1, 2)
     # A C B
@@ -33,8 +33,8 @@ def test_workflow_modification():
     ## Action modifications
     result = w.result
     slots = w.slots
-    list_action =  constructor.list_constr()
-    list_1 = instance.ActionInstance.create(list_action)
+    list_action =  constructor.A_list()
+    list_1 = instance.ActionCall.create(list_action)
     res = w.set_action_input(list_1, 0, slots[0])
     assert res
     res = w.set_action_input(list_1, 1, slots[1])
@@ -45,7 +45,7 @@ def test_workflow_modification():
     assert slots[1].output_actions[0][0] == list_1
     assert list_1.output_actions[0][0] == result
     assert list_1.name == 'list_1'
-    assert len(w._actions) == 4
+    assert len(w._action_calls) == 4
     # w:  (slot0 (B), slot2 (A)) -> List1 -> result
 
 
@@ -63,7 +63,7 @@ def test_workflow_modification():
 
     # Test cycle
     w.set_action_input(list_1, 0, slots[0])
-    list_2 = instance.ActionInstance.create(constructor.list_constr())
+    list_2 = instance.ActionCall.create(constructor.A_list())
     w.set_action_input(list_1, 1, list_2)
     # w:  (slot0 (B), List2) -> List1 -> result
     res = w.set_action_input(list_2, 0, list_1)     # Cycle


### PR DESCRIPTION
- action instance -> action call
- action classes use Camel case
- action instances are published only through ActionWrapper and
accessible as my_action.action
- more consistent Workflow related classes and attributes